### PR TITLE
Display 'seconds' after startTime & endTime on LiveStreamPage

### DIFF
--- a/frontend/src/api/processData.js
+++ b/frontend/src/api/processData.js
@@ -70,8 +70,8 @@ export const fetchAndProcessDataModel = () => {
               url:
                 `${ENV.API_FILE_SERVER}/${incident[0]?.video_id}.mp4` ||
                 'Video Not Found',
-              startTime: incident[0]?.start_time || 'No Start Time',
-              endTime: incident[0]?.end_time || 'No End Time',
+              startTime: incident[0]?.start_time || '0',
+              endTime: incident[0]?.end_time || '0',
               timeStamp: incident[0]?.timestamp || 'No Time Stamp',
               incidentId: incident[0]?.incident_id || 1, // TODO: display 404 of some kind
               objectIdentified: incident[1]?.name || 'No Object Identified',

--- a/frontend/src/features/pageContainer/pages/liveStreamPage/LiveStreamPage.js
+++ b/frontend/src/features/pageContainer/pages/liveStreamPage/LiveStreamPage.js
@@ -76,8 +76,11 @@ const LiveStreamPage = (props) => {
         <div>
           <h1>Incident</h1>
           <DataRow title={'Time Stamp'} data={curIncident.timeStamp} />
-          <DataRow title={'Start Time'} data={curIncident.startTime} />
-          <DataRow title={'End Time'} data={curIncident.endTime} />
+          <DataRow
+            title={'Start Time'}
+            data={`${curIncident.startTime} seconds`}
+          />
+          <DataRow title={'End Time'} data={`${curIncident.endTime} seconds`} />
           <DataRow
             title={'Object Identified'}
             data={curIncident.objectIdentified}


### PR DESCRIPTION
- Incidents with no `startTime` or `endTime` default to 0 seconds.

![Screen Shot 2021-03-08 at 4 02 17 PM](https://user-images.githubusercontent.com/29239796/110397957-a9748e00-8027-11eb-8dab-aadd25d7e316.png)
